### PR TITLE
changed qgis-mapserver to qgis-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -y update
 #-------------Application Specific Stuff ----------------------------------------------------
 
 
-RUN apt-get install -y qgis qgis-mapserver apache2 libapache2-mod-fcgid
+RUN apt-get install -y qgis qgis-server apache2 libapache2-mod-fcgid
 
 EXPOSE 80
 


### PR DESCRIPTION
http://qgis.org/debian/dists/trusty/main/binary-amd64/Packages (and 386) report two packages. qgis-mapserver uses qgis 2.4. qgis-server is marked as: 
Replaces: qgis-mapserver
Provides: qgis-mapserver
