### PR TITLE
Fix #16: Workaround 3.0.3 path issue

### DIFF
--- a/2.18/Dockerfile
+++ b/2.18/Dockerfile
@@ -1,4 +1,4 @@
-FROM kartoza/qgis-desktop:2.18.20
+FROM kartoza/qgis-desktop:2.18.24
 
 # Based off work by
 # Patrick Valsecchi<patrick.valsecchi@camptocamp.com>

--- a/2.18/globals.sh
+++ b/2.18/globals.sh
@@ -2,7 +2,7 @@
 ##
 ## GLOBALS for use by build, test, run etc scripts
 ##
-BUGFIX=20
+BUGFIX=24
 MINOR=18
 MAJOR=2
 TESTPORT=9909

--- a/3.0/build/apache.sh
+++ b/3.0/build/apache.sh
@@ -9,12 +9,6 @@ rm /etc/apache2/mods-enabled/alias.conf
 mkdir -p $APACHE_RUN_DIR $APACHE_LOCK_DIR $APACHE_LOG_DIR
 
 mv /usr/bin/qgis_mapserv.fcgi /usr/lib/cgi-bin/
-# Temporary hack because the compiled fcgi looks for modules in
-# /usr/lib/lib/qgis/server  ... still need to figure out why
-# For now we just move the modules to the expected path
-mkdir /usr/lib/lib
-mv /usr/lib/qgis /usr/lib/lib
-
 
 # Make sure logs go to STDOUT
 sed -ri '

--- a/3.0/runtime/etc/apache2/conf-enabled/qgis.conf
+++ b/3.0/runtime/etc/apache2/conf-enabled/qgis.conf
@@ -2,9 +2,9 @@ ScriptAlias / /usr/lib/cgi-bin/qgis_mapserv.fcgi
 <Location "/">
     SetHandler fcgid-script
     Require all granted
-    PassEnv QGIS_PROJECT_FILE
 </Location>
 
+FcgidInitialEnv QGIS_PROJECT_FILE ${QGIS_PROJECT_FILE}
 FcgidInitialEnv QGIS_LOG_FILE ${QGIS_LOG_FILE}
 FcgidInitialEnv QGIS_SERVER_LOG_FILE ${QGIS_SERVER_LOG_FILE}
 FcgidInitialEnv QGIS_DEBUG ${QGIS_DEBUG}

--- a/3.0/runtime/etc/apache2/conf-enabled/qgis.conf
+++ b/3.0/runtime/etc/apache2/conf-enabled/qgis.conf
@@ -13,3 +13,5 @@ FcgidInitialEnv QGIS_PLUGINPATH "${QGIS_PLUGINPATH}"
 FcgidInitialEnv PGSERVICEFILE ${PGSERVICEFILE}
 FcgidInitialEnv HOME /var/www
 Header set Access-Control-Allow-Origin "*"
+# Temporary workaround for 3.0.3 only:
+FcgidInitialEnv QGIS_PREFIX_PATH "/usr"


### PR DESCRIPTION
The InvalidSRS exception is caused by the following issue, which is fixed since 3.2.0: 
https://issues.qgis.org/issues/18230

(In the qgis logs the following error shows up:
`Could not open CRS database /usr/lib/share/qgis/resources/srs.db`
while the file is located at /usr/share/qgis/resources/srs.db
)

docker-qgis-server already had a partial workaround in place, as in apache.sh /usr/lib/qgis was moved on level deeper to /usr/lib/lib.

This PR replaces this workaround by the one suggested in above qgis issue by supplying FcgidInitialEnv QGIS_PREFIX_PATH "/usr" 
